### PR TITLE
Xcode 12 beta (12A6159)

### DIFF
--- a/xcode.md
+++ b/xcode.md
@@ -35,6 +35,7 @@ Got access to old versions of Apple installers you know are legit? Submit some h
 
 | Version                           | SHA1 Checksum                              | Filename                          |
 | --------------------------------- | ------------------------------------------ | --------------------------------- |
+| [Xcode 12 beta (10.15.4+)][12 beta] (12A6159) | `6c9bd8a762ac01d1030f4cc64f25784f787447bd` | Xcode_12_beta.xip <!-- 780c24db76a80d269d36bf508062d398864e606499439a8dd1d6131876c8078e -->
 | [Xcode 11.6 beta (10.15.2+)][11.6 beta] (11N700h) | `a65fbe2314b3abff410ea9eaeb02eed055fd55df` | Xcode_11.6_beta.xip <!-- 8880e6833acf67e1637831c0375c332cf4bb5ddc69c78ac57be1ff0efcc6a6ac -->
 | [Xcode 11.5 (10.15.2+)][11.5] (11E608c) | `4654b261841d0336cb90ea1c82d15fd7aa03c982` | Xcode_11.5.xip <!-- a5568ae0d30d9d3be94416dbd1aa3a26f23ca5d937c4b9895913cda1b18ceea4 -->
 | [Xcode 11.5 GM Seed (10.15.2+)][11.5 GM Seed] (11E608c) | `4654b261841d0336cb90ea1c82d15fd7aa03c982` | Xcode_11.5_GM_Seed.xip <!-- a5568ae0d30d9d3be94416dbd1aa3a26f23ca5d937c4b9895913cda1b18ceea4 -->
@@ -244,6 +245,7 @@ Got access to old versions of Apple installers you know are legit? Submit some h
  [11.5 GM Seed]: https://download.developer.apple.com/Developer_Tools/Xcode_11.5_GM_Seed/Xcode_11.5_GM_Seed.xip
  [11.5]: https://download.developer.apple.com/Developer_Tools/Xcode_11.5/Xcode_11.5.xip
  [11.6 beta]: https://download.developer.apple.com/Developer_Tools/Xcode_11.6_beta/Xcode_11.6_beta.xip
+ [12 beta]: https://download.developer.apple.com/Developer_Tools/Xcode_12_beta/Xcode_12_beta.xip
 
 ### Xcode Command Line Tools
 


### PR DESCRIPTION
Happy WWDC 2020!

Xcode 12 beta comes in at 9.73GB. That's 1.58GB larger than the previous 11.6 beta from earlier this month. That is A LOT of new APIs. Have fun!

![Screen Shot 2020-06-22 at 12 51 23 PM](https://user-images.githubusercontent.com/499487/85331130-6b7c0d80-b48a-11ea-9862-43b1f07b96e7.png)

Release Notes: https://developer.apple.com/documentation/xcode-release-notes/xcode-12-beta-release-notes

![crg908](https://user-images.githubusercontent.com/499487/85331646-5d7abc80-b48b-11ea-9b6c-7b3f71e8db62.jpg)
