### PR TITLE
Update 10.7.5 Lion (11G63) hashes.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -149,6 +149,8 @@ Get-FileHash -Algorithm SHA1 InstallESD.dmg
 | 10.8.2 Mountain Lion         | `eaf54b1b1a630af85547fed8eabbf6fe159f2b42`
 | 10.8.0 Mountain Lion         | `e5dd2bf5560033cade7dd7d7da5ceec49f701b0e`
 | 10.7.5 Lion                  | `a044fc01fa75b1f255dbdd6ea4fefa30cef147b0`
+| 10.7.5 Lion (11G63)          | `3fae5fe16c7dda2c0fcc3afc49ec1724122a9617`  <!-- 990ab8f88c562c364bed37a5dbbcb67b2dcc0126beff8abdde8e22588b7d92a9 -->
+| 10.7.5 Lion (11G63)          | `a044fc01fa75b1f255dbdd6ea4fefa30cef147b0`  <!-- 8b1e83539a588797087b60a8daab3a45b7a86f42402a38d8075ed5b30c04d798 -->
 | 10.6.0 Snow Leopard (10A432) | `f8fa177e4be9a69f87be23b83c30e0c8eedacf5b`
 | 10.5.0 Leopard (9A581)       | `67ab755a3604cd767787fed56150bdb566358f69`
 

--- a/readme.md
+++ b/readme.md
@@ -148,7 +148,6 @@ Get-FileHash -Algorithm SHA1 InstallESD.dmg
 | 10.8.5 Mountain Lion         | `7bc54f504aa0b769a2d0b8546393a6e0fc24671f`
 | 10.8.2 Mountain Lion         | `eaf54b1b1a630af85547fed8eabbf6fe159f2b42`
 | 10.8.0 Mountain Lion         | `e5dd2bf5560033cade7dd7d7da5ceec49f701b0e`
-| 10.7.5 Lion                  | `a044fc01fa75b1f255dbdd6ea4fefa30cef147b0`
 | 10.7.5 Lion (11G63)          | `3fae5fe16c7dda2c0fcc3afc49ec1724122a9617`  <!-- 990ab8f88c562c364bed37a5dbbcb67b2dcc0126beff8abdde8e22588b7d92a9 -->
 | 10.7.5 Lion (11G63)          | `a044fc01fa75b1f255dbdd6ea4fefa30cef147b0`  <!-- 8b1e83539a588797087b60a8daab3a45b7a86f42402a38d8075ed5b30c04d798 -->
 | 10.6.0 Snow Leopard (10A432) | `f8fa177e4be9a69f87be23b83c30e0c8eedacf5b`


### PR DESCRIPTION
I have two versions of the 10.7.5 Lion (11G63) InstallESD.dmg image. Unfortunately I don't have the exact download dates, as the installer timestamps were modified when copying the installer between filesystems.

The `3fae` one is probably the most recent, as it was also reported as being current by @hirakujira on 3 Feb 2020: https://github.com/notpeter/apple-installer-checksums/pull/71/commits/d7758a3e31900b26d46db804add3533f1325cbe9.

Note that while the file checksums are different, the container checksums (`hdiutil checksum -type SHA1 InstallESD.dmg`) are the same for both images: `8CE7813C1A6E20A1C5993CBFD563BDEE6E2A3B4B`. It seems there was only a change in the metadata or signature of the file.