### PR TITLE
Update 10.9.5 Mavericks (13F34) hashes.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -140,7 +140,8 @@ Get-FileHash -Algorithm SHA1 InstallESD.dmg
 | 10.10.2 Yosemite             | `059f2603a91465bcee24c864d446da30df920f85`
 | 10.10.1 Yosemite             | `a673c2c6d967f4da2934b7d6cf3736936970b194`
 | 10.10.0 Yosemite             | `eebf02a20ac27665a966957eec6f5e6fe3228a19`
-| 10.9.5 Mavericks (13F34)     | `73cdd9440fe5efa79763f5461ec4ad9a59cdd1df`
+| 10.9.5 Mavericks (13F34)     | `73cdd9440fe5efa79763f5461ec4ad9a59cdd1df` <!-- 29b3487a2de846ea6c2015bdb9674c1e44df0ae725ce6110eee3f6be081d1f62 -->
+| 10.9.5 Mavericks (13F34)     | `ba6e42ad05fd002c368f2e37f026b2781c87439e` <!-- 9428f0fd7ae73989fca37cc5712b6a35aa7622987fb0202c5328251d8e75e319 -->
 | 10.9.5 Mavericks             | `4a0a01806be8676cb39fb0ab5d049a198d255538`
 | 10.9.1 Mavericks             | `810ea8356323acf710deb0537bfa1c534e4e54dc`
 | 10.9.0 Mavericks             | `e804dea01e38f8cd28d6c1b1697487e50898dbe7`


### PR DESCRIPTION
I have two versions of the 10.9.5 Mavericks (13F34) InstallESD.dmg image. Unfortunately I don't have the exact download dates, as the installer timestamps were modified when copying the installer between filesystems.

The `73cd` one is probably the most recent, as it was added by @pfranz on 25 Feb 2018: https://github.com/notpeter/apple-installer-checksums/pull/36/commits/d9e56b5355e299f8acac55b35c417a75a0173547, and verified by @markmentovai on 10 Oct 2019: https://github.com/notpeter/apple-installer-checksums/pull/36#issuecomment-540621479. The `ba6e` one was already reported on [8 Jan 2016](https://github.com/sektioneins/osx_verify/blob/579ace8d134ac19918a87e0fb3ac83b4e7a7ea4d/db/Install%20OS%20X%20Mavericks%2010.9.5%2013F34.json#L5805).

Note that while the file checksums are different, the container checksums (`hdiutil checksum -type SHA1 InstallESD.dmg`) are the same for both images: `03BACFDB04046EF058D89F8D3A064924436FB659`. It seems there was only a change in the metadata or signature of the file.